### PR TITLE
Close #1 : don't apply org.springframework.boot when not necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ allprojects {
   apply plugin: 'kotlin'
   apply plugin: 'kotlin-spring'
   apply plugin: 'idea'
-  apply plugin: 'org.springframework.boot'
   apply plugin: 'io.spring.dependency-management'
 
   group = 'cz.zubal'
@@ -40,6 +39,9 @@ allprojects {
     mavenCentral()
   }
 
+  dependencyManagement {
+    imports { mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}") }
+  }
 
   dependencies {
     compile('org.springframework.boot:spring-boot-starter-data-jpa')


### PR DESCRIPTION
* use dependencyManagement to allow all modules to see each other